### PR TITLE
Fix problems with codepage on windows

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,12 +1,13 @@
 
 from setuptools import setup, find_packages
+import io
 
 
-with open('README.md') as file:
+with io.open('README.md', encoding='utf8') as file:
     description = file.read()
 
 
-with open('requirements/main.txt') as file:
+with io.open('requirements/main.txt', encoding='utf8') as file:
     requirements = [_.strip() for _ in file]
 
 


### PR DESCRIPTION
When trying to build on Windows getting a UnicodeDecodeError: 'charmap' codec can't decode byte 0x8f in position 860: character maps to <undefined>

Suspect this is defaulting to CP1252 on Windows, so forcing to utf-8 should help.
This code should work with python2 and python3.